### PR TITLE
fcft: add missing scdoc dep

### DIFF
--- a/kiss-wayland/fcft/depends
+++ b/kiss-wayland/fcft/depends
@@ -1,4 +1,5 @@
 fontconfig
 freetype-harfbuzz
 pixman
+scdoc make
 tllist make


### PR DESCRIPTION
fcft needs scdoc make dep to build succesfully